### PR TITLE
Update manual on getting plugins

### DIFF
--- a/_manual/11_working-with-plugins/06_getting-plugins.html
+++ b/_manual/11_working-with-plugins/06_getting-plugins.html
@@ -131,9 +131,7 @@ title: Getting Plugins
 <p>
   Unless you're a particularly technical computer user, building and
   installing plugins in the LV2 (or LADSPA) format is probably not
-  something worth planning on. Ardour releases for OS X ship with a
-  collection of many LADSPA plugins, some of which are very useful and
-  some of which are outright buggy. 
+  something worth planning on. 
 </p>
 <p>
   Most of the plugins you are likely to use on OS X will be in Apple's


### PR DESCRIPTION
Ardour4 on OS X does not currently provide any LADSPA plugins.
